### PR TITLE
fix: change geometry overlay event type

### DIFF
--- a/tmap/overlay/geometryOverlay.d.ts
+++ b/tmap/overlay/geometryOverlay.d.ts
@@ -47,7 +47,7 @@ declare namespace TMap {
     /**
      * 浏览器原生的事件对象。
      */
-    originalEvent: DocumentEvent;
+    originalEvent: MouseEvent | TouchEvent;
   }
 
   type GeometryOverlayEventListener<T extends Geometry> = (


### PR DESCRIPTION
The type DocumentEvent in geometryOverlayEvent interface should be replaced